### PR TITLE
Changed alert severity to low

### DIFF
--- a/Base Rule Set/Suspicious PowerShell Download  Credential Dump Attempt (6a040bb0-ee6a-43e1-960a-7e4b278e48a0).json
+++ b/Base Rule Set/Suspicious PowerShell Download  Credential Dump Attempt (6a040bb0-ee6a-43e1-960a-7e4b278e48a0).json
@@ -11,7 +11,7 @@
                           "properties":  {
                                              "displayName":  "Suspicious PowerShell Download \u0026 Credential Dump Attempt",
                                              "description":  "Detects suspicious PowerShell usage commonly associated with malware staging or credential dumping, including the use of IEX, Net.WebClient, and tools like Mimikatz.",
-                                             "severity":  "Informational",
+                                             "severity":  "Low",
                                              "enabled":  true,
                                              "query":  "DeviceProcessEvents\r\n| where FileName =~ \"powershell.exe\"\r\n| where ProcessCommandLine has_any (\r\n      \"-EncodedCommand\",\r\n      \"-nop\",\r\n      \"bypass\",\r\n      \"New-Object Net.WebClient\",\r\n      \"Invoke-Expression\",\r\n      \"IEX\",\r\n      \"DownloadString\",\r\n      \"Invoke-Mimikatz\"\r\n  )\r\n   or ProcessCommandLine matches regex @\"[A-Za-z0-9+/=]{80,}\"\r\n| project TimeGenerated, DeviceName, AccountName, InitiatingProcessFileName, ProcessCommandLine\r\n",
                                              "queryFrequency":  "PT1H",


### PR DESCRIPTION
The alert severity does not match the impact of the action flagged by the rule. Severity has been changed from informational to low.